### PR TITLE
 Add Unit & Integration Tests for API Endpoints

### DIFF
--- a/controllers/accountController.js
+++ b/controllers/accountController.js
@@ -4,12 +4,18 @@ const {SendMessageError} = require('../errors');
 
 const getBalanceInfo = async (req, res) => {
     const { settings, return_url } = req.body;
-    const token = (settings.find(setting => setting.label === "Token")).default;    // get the token from the settings
-    setToken(token);
+    
+    const token = (settings?.find(setting => setting.label === "Token"))?.default;    // get the token from the settings
+    console.log(token);
     if (!token) return res.status(400).json({ "status": "error", "message": "The Linode API token was not provided" });
+    if (!return_url) return res.status(400).json({"status": "error", "message": "The return_url was not provided"});
+    
+    setToken(token);
+
 
     try {
         const accountInfo = await getAccountInfo();
+        // console.log(accountInfo);
         // create the message that you want to return 
         const message = helperFunctions.generateMessage(accountInfo);
 

--- a/helpers/sendMessageToChannel.js
+++ b/helpers/sendMessageToChannel.js
@@ -4,7 +4,7 @@ const {SendMessageError} = require('../errors');
 const sendMessageToChannel = async (return_url, data) => {
     try{
         const response = await axios.post(return_url, data);
-        console.log(response);
+        // console.log(response);
     }
     catch(err){
         const error = SendMessageError("There was an issue when sending data to the channel", err);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest tests"
   },
   "keywords": [],
   "author": "",
@@ -19,5 +19,8 @@
   "devDependencies": {
     "jest": "^29.7.0",
     "supertest": "^7.0.0"
+  },
+  "jest": {
+    "testEnvironment": "node"
   }
 }

--- a/tests/balance.test.js
+++ b/tests/balance.test.js
@@ -1,0 +1,71 @@
+const application = require('../app');
+const request = require('supertest');
+require('dotenv').config();
+
+describe("Test the balance endpoint", () => {
+    test("Endpoint should return a status 200 when parameters are there", async () => {
+        const data = {
+            "channel_id": process.env.CHANNEL_ID,
+            "return_url": `https://ping.telex.im/v1/return/${process.env.CHANNEL_ID}`,
+            "settings": [
+                {
+                    "label": "Token",
+                    "default": `${process.env.LINODE_TOKEN}`,
+                    "type": "text",
+                    "required": true
+                },
+                {
+                    "label": "interval",
+                    "type": "text",
+                    "required": true,
+                    "default": "* * * * *"
+                }
+            ]
+        }
+
+        const res = await request(application).post('/account-info/get-balance-info').send(data);
+        expect(res.body.status).toBe("success");
+        expect(res.statusCode).toBe(200);
+    });
+
+    test("Enpoint should return a 400 when the user does not pass a token to the request body", async() => {
+        const data = {
+            "channel_id": process.env.CHANNEL_ID,
+            "return_url": `https://ping.telex.im/v1/return/${process.env.CHANNEL_ID}`,
+            "settings": [
+                {
+                    "label": "interval",
+                    "type": "text",
+                    "required": true,
+                    "default": "* * * * *"
+                }
+            ]
+        };
+
+        const res = await request(application).post('/account-info/get-balance-info').send(data);
+        expect(res.statusCode).toBe(400);
+    });
+
+    test("Should return a status 502 if the wrong API key is used", async() => {
+
+        const res = await request(application).post('/account-info/get-balance-info').send({
+            "channel_id": process.env.CHANNEL_ID,
+            "return_url": `https://ping.telex.im/v1/return/${process.env.CHANNEL_ID}`,
+            "settings": [
+                {
+                    "label": "Token",
+                    "default":"daniel",
+                    "type": "text",
+                    "required": true
+                },
+                {
+                    "label": "interval",
+                    "type": "text",
+                    "required": true,
+                    "default": "* * * * *"
+                }
+            ]
+        });
+        expect(res.statusCode).toBe(502);
+    });
+})

--- a/tests/integrationSpecsRoutes.test.js
+++ b/tests/integrationSpecsRoutes.test.js
@@ -1,0 +1,27 @@
+const application = require('../app');
+const request = require('supertest');
+
+describe("Return JSON settings", () => {
+    // the endpoint should return a JSON file with status 200
+    test("Should return JSON file with 200 status", async() => {
+        const res = await request(application)
+                        .get('/integration-specs');
+        expect(res.statusCode).toBe(200);
+        expect(res.headers['content-type']).toContain('application/json')
+
+    });
+    // the endpoint should return the right data structure
+    test("Should return the correct data structure", async() => {
+        const res = await request(application)
+                            .get('/integration-specs');
+        expect(res.body).toHaveProperty('data');
+        expect(Array.isArray(res.body.data.settings)).toBe(true);
+    })
+
+    // the integration_type and integration_category should be interval and Communication & Collaboration respectively
+    test("integration_type and integration_category should be correct", async() => {
+        const res = await request(application).get('/integration-specs');
+        expect(res.body.data.integration_category).toBe("Communication & Collaboration");
+        expect(res.body.data.integration_type).toBe("interval");
+    })
+})


### PR DESCRIPTION
This PR introduces unit and integration tests to ensure the reliability of the /account-info/get-balance-info and /integration-specs endpoints. The tests validate expected responses, correct data structures, and error handling scenarios.

Changes Made:

✅ Balance Endpoint Tests (/account-info/get-balance-info)

Returns 200 when provided with valid parameters
Returns 400 when required fields are missing
Returns 502 when an incorrect API key is used (Further investigation needed as this sometimes returns 200)
✅ Integration-Specs Endpoint Tests (/integration-specs)

Ensures endpoint returns a 200 status with JSON content
Verifies the correct data structure (e.g., data.settings should be an array)
Confirms integration_type and integration_category return expected values
How to Test:

Run `npm test` to execute all test cases.
Verify that all expected test assertions pass.